### PR TITLE
Added Support for Laravel 5.1 and Above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
 # blade-variable
-
-Declaring variable in Laravel blade files.
+Declaring variables in Laravel blade files.
 
 ## Installation
-
-Add this line to `composer.json` file-
+Add this line to `composer.json` file (for Laravel 5.1 and Above) - 
 
 ```
 require: {
     ...,
-    "milon/laravel-blade": "dev-master"
+    "milon/laravel-blade": "~2.0"
 }
 ```
 
-Then from your terminal run this command-
+Add this line to `composer.json` file (for Laravel 4.2 and Above) - 
+
+```
+require: {
+    ...,
+    "milon/laravel-blade": "~1.0"
+}
+```
+
+Then from your terminal run this command -
 
 ```
 composer update
@@ -23,13 +30,13 @@ After that add this line to `providers` array on `config/app.php` file-
 
 ```
 'providers' => [
-...,
-Milon\BladeVariable\BladeVariableServiceProvider::class,
+    ...,
+    Milon\BladeVariable\BladeVariableServiceProvider::class,
 ]
 ```
 
-## Usage
 
+## Usage
 You can define any variable in blade file like this-
 
 ```
@@ -42,7 +49,7 @@ Then you can use this like any other normal php variable-
 {{ $name }}
 ```
 
-## Copyright
 
+## Copyright
 Nuruzzaman Milon  
 http://milon.im

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.*"
+        "laravel/framework": "~5.1"
     },
     "autoload": {
         "psr-0": {

--- a/src/Milon/BladeVariable/BladeVariableServiceProvider.php
+++ b/src/Milon/BladeVariable/BladeVariableServiceProvider.php
@@ -18,10 +18,9 @@ class BladeVariableServiceProvider extends ServiceProvider
     {
         $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
-        $blade->extend( function($value, $compiler)
-		{
-			return preg_replace("/@var\('(.*?)'\,(.*)\)/", '<?php $$1 = $2; ?>', $value);
-		});
+        $blade->directive('var', function ($exp) {
+            return preg_replace("/\('(.*?)'\,(.*)\)/", '<?php $$1 = $2; ?>', $exp);
+        });
     }
 
 }


### PR DESCRIPTION
Firstly, I would suggest **not** merging this into master. That'd make everything very disorganized.
Please open a new branch with a different version number so that the master can contain the previous version with support for Laravel 4.2 to 5.0.

Also, tagging on the master with v1.x and tagging on the new branch v2.x would allow users of different versions of the framework to download the appropriate version to work with their version of the BladeCompiler.
